### PR TITLE
webrtc implementation (chrome & c++)

### DIFF
--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -44,7 +44,9 @@ find_package(PkgConfig 0.29.1 REQUIRED)
 pkg_check_modules(GST_MODULES  REQUIRED                  
                   gstreamer-1.0>=1.14.0
                   gstreamer-base-1.0>=1.14.0
-				  gstreamer-rtsp-server-1.0)
+                  gstreamer-rtsp-server-1.0
+                  gstreamer-sdp-1.0
+                  gstreamer-webrtc-1.0)
 
 include_directories(${GST_MODULES_INCLUDE_DIRS}) 
 link_directories   (${GST_MODULES_LIBRARY_DIRS})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -43,3 +43,5 @@ add_test(NAME run-webstreamer-test
 
 SET_TESTS_PROPERTIES(run-webstreamer-test
  PROPERTIES ENVIRONMENT "LIBWEBSTREAMER_PATH=${instd}")
+
+ADD_DEFINITIONS( -DGST_USE_UNSTABLE_API  )

--- a/lib/app/livestream.h
+++ b/lib/app/livestream.h
@@ -59,18 +59,22 @@ class LiveStream : public IApp
     void remove_audience(Promise *promise);
     void Startup(Promise *promise);
     void Stop(Promise *promise);
+    void set_remote_description(Promise *promise);
+    void set_remote_candidate(Promise *promise);
 
     bool on_add_endpoint(IEndpoint *endpoint);
     virtual bool MessageHandler(GstMessage *msg);
 
  private:
     static GstPadProbeReturn
-	on_tee_pad_remove_video_probe(GstPad *pad,
-		GstPadProbeInfo *probe_info, gpointer data);
+    on_tee_pad_remove_video_probe(GstPad *pad,
+                                  GstPadProbeInfo *probe_info,
+                                  gpointer data);
 
     static GstPadProbeReturn
-	on_tee_pad_remove_audio_probe(GstPad *pad,
-		GstPadProbeInfo *probe_info, gpointer data);
+    on_tee_pad_remove_audio_probe(GstPad *pad,
+                                  GstPadProbeInfo *probe_info,
+                                  gpointer data);
 
     static GstPadProbeReturn on_monitor_data(GstPad *pad,
                                              GstPadProbeInfo *info,
@@ -82,8 +86,8 @@ class LiveStream : public IApp
     std::list<IEndpoint *> audiences_;
 
     std::list<sink_link *> sinks_;  // all the request pad of tee,
-	                                // release when removing from
-	                                // pipeline
+                                    // release when removing from
+                                    // pipeline
 
     GstPad *video_tee_pad_;
     GstElement *fake_video_queue_;

--- a/lib/app/webrtctestclient.cc
+++ b/lib/app/webrtctestclient.cc
@@ -59,6 +59,16 @@ static gboolean message_handler(GstBus *bus,
 void WebRTCTestClient::Startup(Promise *promise)
 {
     if (webrtc_ep_) {
+        const json &j = promise->data();
+        std::string launch;
+        if (j.find("launch") != j.end()) {
+            launch = j["launch"];
+        } else {
+            promise->reject("webrtc test client startup failed! No launch!");
+            return;
+        }
+        // printf("launch: %s\n", launch.c_str());
+        webrtc_ep_->launch() = launch;
         if (webrtc_ep_->initialize(promise)) {
             GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(webrtc_ep_->pipeline()));
             gst_bus_add_watch(bus, message_handler, this);

--- a/lib/app/webrtctestclient.cc
+++ b/lib/app/webrtctestclient.cc
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 KEDACOM Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "webrtctestclient.h"
+
+using json = nlohmann::json;
+
+bool WebRTCTestClient::Initialize(Promise *promise)
+{
+    webrtc_ep_ = new WebRTC(this, "test");
+    return true;
+}
+
+bool WebRTCTestClient::Destroy(Promise *promise)
+{
+    if (webrtc_ep_) {
+        delete webrtc_ep_;
+        webrtc_ep_ = NULL;
+    }
+    return true;
+}
+
+void WebRTCTestClient::On(Promise *promise)
+{
+    const json &j = promise->meta();
+    std::string action = j["action"];
+    if (action == "startup") {
+        Startup(promise);
+    } else if (action == "stop") {
+        Stop(promise);
+    } else if (action == "remote_sdp") {
+        set_remote_description(promise);
+    } else if (action == "remote_candidate") {
+        set_remote_candidate(promise);
+    }
+}
+static gboolean message_handler(GstBus *bus,
+                                GstMessage *message,
+                                gpointer data)
+{
+    ElementWatcher *This = static_cast<ElementWatcher *>(data);
+    This->OnMessage(bus, message);
+
+    return TRUE;
+}
+void WebRTCTestClient::Startup(Promise *promise)
+{
+    if (webrtc_ep_) {
+        if (webrtc_ep_->initialize(promise)) {
+            GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(webrtc_ep_->pipeline()));
+            gst_bus_add_watch(bus, message_handler, this);
+            gst_object_unref(bus);
+
+            promise->resolve();
+            return;
+        }
+    }
+    promise->reject("webrtc test client startup failed!");
+}
+
+
+void WebRTCTestClient::Stop(Promise *promise)
+{
+    if (webrtc_ep_) {
+        webrtc_ep_->terminate();
+        promise->resolve();
+        return;
+    }
+    promise->reject("webrtc test client stop failed!");
+}
+
+void WebRTCTestClient::set_remote_description(Promise *promise)
+{
+    if (webrtc_ep_) {
+        webrtc_ep_->set_remote_description(promise);
+        promise->resolve();
+        return;
+    }
+    promise->reject("webrtc test client set_remote_description failed!");
+}
+void WebRTCTestClient::set_remote_candidate(Promise *promise)
+{
+    if (webrtc_ep_) {
+        webrtc_ep_->set_remote_candidate(promise);
+        promise->resolve();
+        return;
+    }
+    promise->reject("webrtc test client set_remote_candidate failed!");
+}

--- a/lib/app/webrtctestclient.h
+++ b/lib/app/webrtctestclient.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 KEDACOM Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _LIBWEBSTREAMER_WEBRTC_TEST_CLIENT_H_
+#define _LIBWEBSTREAMER_WEBRTC_TEST_CLIENT_H_
+
+#include <endpoint/webrtc.h>
+#include <app/elementwatcher.h>
+
+class WebRTCTestClient : public ElementWatcher
+{
+ public:
+    APP(WebRTCTestClient)
+    WebRTCTestClient(const std::string &name, WebStreamer *ws)
+        : ElementWatcher(name, ws)
+        , webrtc_ep_(NULL)
+    {
+    }
+
+    virtual void On(Promise *promise);
+    virtual bool Initialize(Promise *promise);
+    virtual bool Destroy(Promise *promise);
+
+ private:
+    void Startup(Promise *promise);
+    void Stop(Promise *promise);
+    void set_remote_description(Promise *promise);
+    void set_remote_candidate(Promise *promise);
+
+    WebRTC *webrtc_ep_;
+};
+#endif

--- a/lib/endpoint/rtspservice.cc
+++ b/lib/endpoint/rtspservice.cc
@@ -37,11 +37,11 @@ IRTSPService::~IRTSPService()
 
 std::mutex IRTSPService::client_mutex_;
 
-static void Notify(gpointer data, GObject *where_the_object_was)
-{
-    g_print(" data : %x\n", data);
-    g_print(" where_the_object_was : %x\n", where_the_object_was);
-}
+// static void Notify(gpointer data, GObject *where_the_object_was)
+// {
+//     g_print(" data : %x\n", data);
+//     g_print(" where_the_object_was : %x\n", where_the_object_was);
+// }
 
 void IRTSPService::on_new_session(GstRTSPClient *client,
                                   GstRTSPSession *session,
@@ -112,7 +112,7 @@ bool IRTSPService::Launch(const std::string &path,
 
     GST_DEBUG("[rtsp-server] %s launched to %s", name().c_str(), path.c_str());
     path_ = path;
-    g_object_weak_ref(G_OBJECT(factory_), Notify, factory_);
+    // g_object_weak_ref(G_OBJECT(factory_), Notify, factory_);
 
     g_signal_connect(server, "client-connected", (GCallback)on_client_connected, (gpointer)(this));
 

--- a/lib/endpoint/webrtc.cc
+++ b/lib/endpoint/webrtc.cc
@@ -13,3 +13,220 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "webrtc.h"
+#include <utils/typedef.h>
+#include <gst/sdp/sdp.h>
+#include <gst/webrtc/webrtc.h>
+
+using json = nlohmann::json;
+
+GST_DEBUG_CATEGORY_STATIC(my_category);
+#define GST_CAT_DEFAULT my_category
+
+WebRTC::WebRTC(IApp *app, const std::string &name)
+    : IEndpoint(app, name)
+    , pipeline_(NULL)
+    , webrtc_(NULL)
+{
+}
+
+WebRTC::~WebRTC()
+{
+}
+
+
+void WebRTC::on_ice_candidate(GstElement *webrtc_element G_GNUC_UNUSED,
+                              guint mlineindex,
+                              gchar *candidate,
+                              gpointer user_data G_GNUC_UNUSED)
+{
+    WebRTC *webrtc = static_cast<WebRTC *>(user_data);
+    json data;
+    data["candidate"] = candidate;
+    data["sdpMLineIndex"] = mlineindex;
+
+    std::string ice_candidate = data.dump();
+
+    // printf("\nice:%s\n", ice_candidate.c_str());
+
+    json meta;
+    meta["topic"] = "webrtc";
+    meta["origin"] = webrtc->app()->uname();
+    meta["type"] = "candidate";
+
+    GST_DEBUG("[webrtc] %p local candidate created.", webrtc->webrtc_);
+
+    webrtc->app()->Notify(data, meta);
+}
+void WebRTC::on_offer_created(GstPromise *promise, gpointer user_data)
+{
+    WebRTC *webrtc = static_cast<WebRTC *>(user_data);
+    GstWebRTCSessionDescription *offer = NULL;
+    // g_assert_cmphex(gst_promise_wait(promise), ==, GST_PROMISE_RESULT_REPLIED);
+    const GstStructure *reply = gst_promise_get_reply(promise);
+    gst_structure_get(reply, "offer", GST_TYPE_WEBRTC_SESSION_DESCRIPTION, &offer, NULL);
+    gst_promise_unref(promise);
+    // gst_sdp_media_add_attribute((GstSDPMedia *)&g_array_index(offer->sdp->medias, GstSDPMedia, 0),
+    //                             "fmtp",
+    //                             "96 profile-level-id=42e01f");
+
+    promise = gst_promise_new();
+    g_signal_emit_by_name(webrtc->webrtc_, "set-local-description", offer, promise);
+    gst_promise_interrupt(promise);
+    gst_promise_unref(promise);
+
+    /* Send offer to peer */
+    std::string sdp_offer(gst_sdp_message_as_text(offer->sdp));
+    json data;
+    data["type"] = "offer";
+    data["sdp"] = sdp_offer;
+    json meta;
+    meta["topic"] = "webrtc";
+    meta["origin"] = webrtc->app()->uname();
+    meta["type"] = "offer";
+
+    GST_DEBUG("[webrtc] %p local description created.", webrtc->webrtc_);
+
+    webrtc->app()->Notify(data, meta);
+
+    gst_webrtc_session_description_free(offer);
+}
+void WebRTC::on_negotiation_needed(GstElement *element, gpointer user_data)
+{
+    WebRTC *webrtc = static_cast<WebRTC *>(user_data);
+    GstPromise *promise = gst_promise_new_with_change_func(on_offer_created, user_data, NULL);
+    g_signal_emit_by_name(webrtc->webrtc_, "create-offer", NULL, promise);
+}
+
+bool WebRTC::initialize(Promise *promise)
+{
+    GST_DEBUG_CATEGORY_INIT(my_category, "webstreamer", 2, "libWebStreamer");
+    IEndpoint::protocol() = "webrtc";
+
+    GError *error = NULL;
+
+    std::string launch = "webrtcbin name=sendrecv ";
+    if (!app()->video_encoding().empty()) {
+        std::string video_enc = app()->video_encoding();
+        // launch += "rtspsrc location=rtsp://172.16.66.65/id=1 ! rtph264depay ! queue ! ";
+        launch += "rtp" + video_enc + "pay name=pay0 ! queue ! " +
+                  "application/x-rtp,media=video,encoding-name=" + uppercase(video_enc) +
+                  ",payload=96 ! sendrecv. ";
+    }
+    if (!app()->audio_encoding().empty()) {
+        std::string audio_enc = app()->audio_encoding();
+        launch += "rtp" + audio_enc + "pay name=pay1 ! queue ! " +
+                  "application/x-rtp,media=audio,encoding-name=" + uppercase(audio_enc) +
+                  ",payload=97 ! sendrecv. ";
+    }
+    pipeline_ = gst_parse_launch(launch.c_str(), &error);
+
+    if (error) {
+        GST_ERROR("[webrtc] Failed to parse launch: %s", error->message);
+        g_error_free(error);
+        g_clear_object(&pipeline_);
+        pipeline_ = NULL;
+        return false;
+    }
+    g_assert_nonnull(pipeline_);
+    webrtc_ = gst_bin_get_by_name(GST_BIN(pipeline_), "sendrecv");
+
+    if (app()->video_encoding() == "h264") {
+        GstElement *payloader = gst_bin_get_by_name(GST_BIN(pipeline_), "pay0");
+        g_object_set(G_OBJECT(payloader), "config-interval", -1, NULL);
+        gst_object_unref(payloader);
+    }
+
+    g_signal_connect(webrtc_, "on-negotiation-needed", G_CALLBACK(WebRTC::on_negotiation_needed), this);
+    g_signal_connect(webrtc_, "on-ice-candidate", G_CALLBACK(WebRTC::on_ice_candidate), this);
+    // g_signal_connect(webrtc_, "pad-added", G_CALLBACK(WebRTC::on_incoming_stream), pipeline_);
+
+    static int session_count = 0;
+    if (!app()->video_encoding().empty()) {
+        GST_DEBUG("[webrtc] %p media constructed: video", webrtc_);
+
+        static std::string media_type = "video";
+        std::string pipejoint_name = std::string("webrtc_video_endpoint_joint_") +
+                                     name() +
+                                     std::to_string(session_count);
+        video_joint_ = make_pipe_joint(media_type, pipejoint_name);
+
+        app()->add_pipe_joint(video_joint_.upstream_joint);
+
+        g_warn_if_fail(gst_bin_add(GST_BIN(pipeline_), video_joint_.downstream_joint));
+
+        GstElement *video_pay = gst_bin_get_by_name_recurse_up(GST_BIN(pipeline_), "pay0");
+        g_warn_if_fail(gst_element_link(video_joint_.downstream_joint, video_pay));
+    }
+    if (!app()->audio_encoding().empty()) {
+        GST_DEBUG("[webrtc] %p media constructed: audio", webrtc_);
+
+        static std::string media_type = "audio";
+        std::string pipejoint_name = std::string("webrtc_audio_endpoint_joint_") +
+                                     name() +
+                                     std::to_string(session_count);
+        audio_joint_ = make_pipe_joint(media_type, pipejoint_name);
+
+        app()->add_pipe_joint(audio_joint_.upstream_joint);
+
+        g_warn_if_fail(gst_bin_add(GST_BIN(pipeline_), audio_joint_.downstream_joint));
+
+        GstElement *audio_pay = gst_bin_get_by_name_recurse_up(GST_BIN(pipeline_), "pay0");
+        g_warn_if_fail(gst_element_link(audio_joint_.downstream_joint, audio_pay));
+    }
+    session_count++;
+
+
+    GstStateChangeReturn ret = gst_element_set_state(pipeline_, GST_STATE_PLAYING);
+    if (ret == GST_STATE_CHANGE_FAILURE) {
+        GST_DEBUG("[webrtc] %p initialize failed.", webrtc_);
+    }
+    GST_DEBUG("[webrtc] %p initialize done.", webrtc_);
+
+    return true;
+}
+
+void WebRTC::terminate()
+{
+    // dynamicly unlink
+    if (!app()->video_encoding().empty() &&
+        video_joint_.upstream_joint != NULL) {
+        app()->remove_pipe_joint(video_joint_.upstream_joint);
+    }
+    if (!app()->audio_encoding().empty() &&
+        audio_joint_.upstream_joint != NULL) {
+        app()->remove_pipe_joint(audio_joint_.upstream_joint);
+    }
+    if (pipeline_) {
+        gst_element_set_state(GST_ELEMENT(pipeline_), GST_STATE_NULL);
+        gst_object_unref(pipeline_);
+    }
+    if (webrtc_) {
+        gst_object_unref(webrtc_);
+        webrtc_ = NULL;
+    }
+}
+
+void WebRTC::set_remote_description(Promise *promise)
+{
+    const json &j = promise->data();
+    std::string sdp_info = j["sdp"];
+
+    GstWebRTCSessionDescription *answer;
+    GstSDPMessage *sdp;
+    gst_sdp_message_new(&sdp);
+    gst_sdp_message_parse_buffer((guint8 *)sdp_info.c_str(), (guint)sdp_info.size(), sdp);
+    answer = gst_webrtc_session_description_new(GST_WEBRTC_SDP_TYPE_ANSWER, sdp);
+
+    g_signal_emit_by_name(webrtc_, "set-remote-description", answer, NULL);
+    GST_DEBUG("[webrtc] %p set remote description.", webrtc_);
+}
+void WebRTC::set_remote_candidate(Promise *promise)
+{
+    const json &j = promise->data();
+    std::string candidate = j["candidate"];
+    int sdpmlineindex = j["sdpMLineIndex"];
+    g_signal_emit_by_name(webrtc_, "add-ice-candidate", sdpmlineindex, candidate.c_str());
+    GST_DEBUG("[webrtc] %p set remote candidate.", webrtc_);
+}

--- a/lib/endpoint/webrtc.cc
+++ b/lib/endpoint/webrtc.cc
@@ -129,9 +129,10 @@ bool WebRTC::initialize(Promise *promise)
             launch_ += "rtp" + audio_enc + "pay name=pay1 ! queue ! " +
                        "application/x-rtp,media=audio,encoding-name=" + uppercase(audio_enc);
             if (uppercase(audio_enc) == "PCMA") {
-                launch_ += ",clock-rate=8000";
+                launch_ += ",payload=8 ! webrtc. ";
+            } else {
+                launch_ += ",payload=97 ! webrtc. ";
             }
-            launch_ += ",payload=97 ! webrtc. ";
         }
     } else {
         role_ = "answer";

--- a/lib/endpoint/webrtc.cc
+++ b/lib/endpoint/webrtc.cc
@@ -67,9 +67,9 @@ void WebRTC::on_sdp_created(GstPromise *promise, gpointer user_data)
     const GstStructure *reply = gst_promise_get_reply(promise);
     gst_structure_get(reply, webrtc->role_.c_str(), GST_TYPE_WEBRTC_SESSION_DESCRIPTION, &sdp, NULL);
     gst_promise_unref(promise);
-    // gst_sdp_media_add_attribute((GstSDPMedia *)&g_array_index(offer->sdp->medias, GstSDPMedia, 0),
-    //                             "fmtp",
-    //                             "96 profile-level-id=42e01f");
+    gst_sdp_media_add_attribute((GstSDPMedia *)&g_array_index(sdp->sdp->medias, GstSDPMedia, 0),
+                                "fmtp",
+                                "96 profile-level-id=42e01f");
 
 
     /* Send sdp to peer */

--- a/lib/endpoint/webrtc.h
+++ b/lib/endpoint/webrtc.h
@@ -33,21 +33,26 @@ class WebRTC : public IEndpoint
     void set_remote_description(Promise *promise);
     void set_remote_candidate(Promise *promise);
 
+    GstElement *pipeline() { return pipeline_; }
+
  private:
     static void on_ice_candidate(GstElement *webrtc G_GNUC_UNUSED,
                                  guint mlineindex,
                                  gchar *candidate,
                                  gpointer user_data G_GNUC_UNUSED);
-    static void on_offer_created(GstPromise *promise, gpointer user_data);
+    static void on_sdp_created(GstPromise *promise, gpointer user_data);
     static void on_negotiation_needed(GstElement *element, gpointer user_data);
+    static void on_webrtc_pad_added(GstElement *webrtc, GstPad *new_pad, gpointer user_data);
 
 
     bool add_to_pipeline();
 
     GstElement *pipeline_;
+    GstElement *bin_;
     GstElement *webrtc_;
 
     PipeJoint video_joint_;
     PipeJoint audio_joint_;
+    std::string role_;
 };
 #endif

--- a/lib/endpoint/webrtc.h
+++ b/lib/endpoint/webrtc.h
@@ -34,6 +34,7 @@ class WebRTC : public IEndpoint
     void set_remote_candidate(Promise *promise);
 
     GstElement *pipeline() { return pipeline_; }
+    std::string &launch() { return launch_; }
 
  private:
     static void on_ice_candidate(GstElement *webrtc G_GNUC_UNUSED,
@@ -54,5 +55,6 @@ class WebRTC : public IEndpoint
     PipeJoint video_joint_;
     PipeJoint audio_joint_;
     std::string role_;
+    std::string launch_;
 };
 #endif

--- a/lib/endpoint/webrtc.h
+++ b/lib/endpoint/webrtc.h
@@ -13,3 +13,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#ifndef _LIBWEBSTREAMER_ENDPOINT_WEBRTC_H_
+#define _LIBWEBSTREAMER_ENDPOINT_WEBRTC_H_
+
+
+#include <framework/app.h>
+#include <utils/pipejoint.h>
+
+class WebRTC : public IEndpoint
+{
+ public:
+    WebRTC(IApp *app, const std::string &name);
+    ~WebRTC();
+
+    virtual bool initialize(Promise *promise);
+    virtual void terminate();
+
+    void set_remote_description(Promise *promise);
+    void set_remote_candidate(Promise *promise);
+
+ private:
+    static void on_ice_candidate(GstElement *webrtc G_GNUC_UNUSED,
+                                 guint mlineindex,
+                                 gchar *candidate,
+                                 gpointer user_data G_GNUC_UNUSED);
+    static void on_offer_created(GstPromise *promise, gpointer user_data);
+    static void on_negotiation_needed(GstElement *element, gpointer user_data);
+
+
+    bool add_to_pipeline();
+
+    GstElement *pipeline_;
+    GstElement *webrtc_;
+
+    PipeJoint video_joint_;
+    PipeJoint audio_joint_;
+};
+#endif

--- a/lib/utils/typedef.cc
+++ b/lib/utils/typedef.cc
@@ -41,3 +41,14 @@ AudioEncodingType get_audio_encoding_type(const std::string &type)
 {
     return audio_encoding_type[type];
 }
+
+std::string uppercase(const std::string target)
+{
+    std::string result = target;
+    for (int i = 0; i < result.size(); ++i) {
+        if (result[i] >= 97 && result[i] <= 122) {
+            result[i] -= 32;
+        }
+    }
+    return result;
+}

--- a/lib/utils/typedef.h
+++ b/lib/utils/typedef.h
@@ -43,4 +43,6 @@ EndpointType get_endpoint_type(const std::string &type);
 VideoEncodingType get_video_encoding_type(const std::string &type);
 AudioEncodingType get_audio_encoding_type(const std::string &type);
 
+std::string uppercase(const std::string target);
+
 #endif

--- a/lib/webstreamer.h
+++ b/lib/webstreamer.h
@@ -23,6 +23,7 @@
 #include <app/elementwatcher.h>
 #include <app/rtsptestclient.h>
 #include <app/livestream.h>
+#include <app/webrtctestclient.h>
 #include <framework/rtspserver.h>
 
 
@@ -121,7 +122,8 @@ class WebStreamer {
  protected:
     typedef AppFactory<RTSPTestServer,
                        ElementWatcher,
-                       LiveStream>
+                       LiveStream,
+                       WebRTCTestClient>
         Factory;
 
 


### PR DESCRIPTION
the signal bridge uses `simple-server.py` in [gstwebrtc-demo](https://github.com/yjjnls/gstwebrtc-demos/tree/master/signalling)     
and the front-end web uses `index.html` in [sendrecv demo](https://github.com/yjjnls/gstwebrtc-demos/tree/master/sendrecv/js)